### PR TITLE
Explicitly use Domain::OrderLine

### DIFF
--- a/lib/domain/order.rb
+++ b/lib/domain/order.rb
@@ -70,7 +70,7 @@ module Domain
     end
 
     def create_order_line(product_id)
-      OrderLine.new(product_id)
+      Domain::OrderLine.new(product_id)
     end
 
     def remove_order_line(order_line)


### PR DESCRIPTION
For some reason ActiveSupport resolved `OrderLine` in this context to the `OrderLine` model, and not the `Domain::OrderLine` class...